### PR TITLE
Development

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly
+ - package-ecosystem: "docker"
+   directory: "/"
+   schedule:
+     interval: weekly
+ - package-ecosystem: "docker-compose"
+   directory: "/"
+   schedule:
+     interval: weekly
+ - package-ecosystem: "github-actions"
+   directory: "/"
+   schedule:
+     interval: weekly
+ - package-ecosystem: "uv"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ on:
   schedule:
     - cron: '44 6 * * 2'
 
-jjobs:
+jobs:
   call-workflow:
     permissions:
       # required for all workflows

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![Test](https://github.com/road-master/radiko-podcast/workflows/Test/badge.svg)](https://github.com/road-master/radiko-podcast/actions?query=workflow%3ATest)
 [![CodeQL](https://github.com/road-master/radiko-podcast/workflows/CodeQL/badge.svg)](https://github.com/road-master/radiko-podcast/actions?query=workflow%3ACodeQL)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/9b52f1765b2e797d293d/test_coverage)](https://codeclimate.com/github/road-master/radiko-podcast/test_coverage)
-[![Maintainability](https://api.codeclimate.com/v1/badges/9b52f1765b2e797d293d/maintainability)](https://codeclimate.com/github/road-master/radiko-podcast/maintainability)
-[![Code Climate technical debt](https://img.shields.io/codeclimate/tech-debt/road-master/radiko-podcast)](https://codeclimate.com/github/road-master/radiko-podcast)
+[![Code Coverage](https://qlty.sh/gh/road-master/projects/radiko-podcast/coverage.svg)](https://qlty.sh/gh/road-master/projects/radiko-podcast)
+[![Maintainability](https://qlty.sh/gh/road-master/projects/radiko-podcast/maintainability.svg)](https://qlty.sh/gh/road-master/projects/radiko-podcast)
+[![Dependabot](https://flat.badgen.net/github/dependabot/road-master/radiko-podcast?icon=dependabot)](https://github.com/road-master/radiko-podcast/security/dependabot)
 [![Python versions](https://img.shields.io/pypi/pyversions/radikopodcast.svg)](https://pypi.org/project/radikopodcast)
-[![Twitter URL](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Fgithub.com%2Froad-master%2Fradiko-podcast)](http://twitter.com/share?text=radiko%20Podcast&url=https://pypi.org/project/radikopodcast/&hashtags=python)
+[![X URL](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Fgithub.com%2Froad-master%2Fradiko-podcast)](https://x.com/intent/post?text=radiko%20Podcast&url=https%3A%2F%2Fpypi.org%2Fproject%2Fradikopodcast%2F&hashtags=python)
 
 タイムフリー 1 週間では足りない人向けの radiko 番組自動アーカイブコマンドです
 
@@ -65,6 +65,12 @@ keywords:
   - "K's Transmission"
   - "ROPPONGI PASSION PIT"
   - "カフェイン11"
+# タイムフリー30 プランに加入したアカウントでログインした際の radiko_session を設定すると、
+# 30 日まで遡ってアーカイブできます
+# この値は開発者ツールの Network タブを開き、
+# ログインした radiko で画面遷移した際のリクエストをクリック、
+# Headers タブで Request Headers の Cookie を参照するなどして確認できます
+radiko_session: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
 ### 3. `output/` ディレクトリーの作成

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Internet",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Internet :: WWW/HTTP :: Indexing/Search",


### PR DESCRIPTION
## Summary

- Add Dependabot configuration for automated dependency updates across devcontainers, Docker, docker-compose, GitHub Actions, and uv ecosystems (weekly schedule)
- Fix typo in CodeQL workflow: `jjobs:` → `jobs:`
- Migrate badges from CodeClimate to qlty.sh for Code Coverage and Maintainability; add Dependabot badge; update Twitter share link to X (formerly Twitter)
- Document `radiko_session` config option for タイムフリー30 plan users to archive up to 30 days back
- Add Python 3.13 classifier to `pyproject.toml`

## Changes

### `.github/dependabot.yml` (new)
Enables weekly Dependabot version updates for all relevant package ecosystems.

### `.github/workflows/codeql.yml`
Fixes a typo (`jjobs` → `jobs`) that was preventing the CodeQL workflow from running.

### `README.md`
- Replaces CodeClimate badges with qlty.sh equivalents
- Adds a Dependabot security badge
- Updates the social share button from Twitter to X
- Adds a YAML comment block explaining how to obtain and configure `radiko_session` for タイムフリー30 subscribers

### `pyproject.toml`
Adds `Programming Language :: Python :: 3.13` classifier to reflect Python 3.13 support.

## Test plan
- [ ] Confirm CodeQL workflow runs successfully (no more `jjobs` typo)
- [ ] Verify Dependabot PRs are created on schedule for each configured ecosystem
- [ ] Check README badges render correctly on GitHub
