### PR TITLE
Upgrade dependencies

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -15,8 +15,6 @@ services:
     # docker-compose.yml file (the first in the devcontainer.json "dockerComposeFile"
     # array). The sample below assumes your primary file is in the root of your project.
     #
-    entrypoint: []
-    
     volumes:
       # Update this to wherever you want VS Code to mount the folder of your project
       - .:/workspace:cached

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,9 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+permissions:
+  contents: read  # Advanced Security suggested for Principle of Least Privilege in pull request review
+  packages: read  # Advanced Security suggested for Principle of Least Privilege in pull request review
 jobs:
   call-workflow:
     uses: yukihiko-shinoda/invoke-lint/.github/workflows/reusable-deploy.yml@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,15 @@ on:
   pull_request:
     branches:
       - main
+permissions:
+  contents: read  # Advanced Security suggested for Principle of Least Privilege in pull request review
+  packages: read  # Advanced Security suggested for Principle of Least Privilege in pull request review
 jobs:
   call-workflow-test:
     uses: yukihiko-shinoda/invoke-lint/.github/workflows/reusable-test.yml@main
     with:
-      support-python-versions: "[ '3.13', '3.12', '3.11', '3.10', '3.9' ]"
+      support-python-versions: "[ '3.14', '3.13', '3.12', '3.11', '3.10', '3.9' ]"
   call-workflow-lint:
     uses: yukihiko-shinoda/invoke-lint/.github/workflows/reusable-lint.yml@main
+    with:
+      enable-xenon: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM futureys/claude-code-python-development:20260407212500
+FROM futureys/claude-code-python-development:20260515203000
 RUN apt-get update && apt-get install --no-install-recommends -y \
     curl/stable \
     xz-utils/stable \
@@ -13,8 +13,7 @@ RUN curl --location https://github.com/BtbN/FFmpeg-Builds/releases/download/auto
 COPY libavdevice_so.conf /etc/ld.so.conf.d/
 RUN ldconfig
 COPY radikopodcast LICENSE pyproject.toml README.md /workspace/
-RUN uv sync --python 3.13
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync
 COPY . /workspace/
 VOLUME ["/workspace/output"]
-ENTRYPOINT [ "uv", "run" ]
-CMD ["pytest"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,13 @@ dev = [
   # - dlint/requirements.txt at 0.13.0 · dlint-py/dlint
   #   https://github.com/dlint-py/dlint/blob/0.13.0/requirements.txt#L1
   "dlint>=0.14.0",
-  # To the docformatter load pyproject.toml settings:
-  "docformatter[tomli]; python_version < '3.11'",
-  "docformatter; python_version >= '3.11'",
+  # We exclude docformatter versions before 1.7.8 because they depend on untokenize==0.1.1,
+  # whose setup.py uses ast.Constant.s that was removed in Python 3.14.
+  # docformatter 1.7.8 and later require Python 3.10 or later instead of untokenize.
+  # And, we specify as follows if the latest supported Python version is less than 3.11,
+  # so that docformatter can read the settings in pyproject.toml:
+  "docformatter[tomli]>=1.7.8; python_version < '3.11' and python_version >= '3.10'",
+  "docformatter>=1.7.8; python_version >= '3.11'",
   "dodgy",
   # The hacking depends flake8 ~=6.1.0 or ~=5.0.1 or ~=4.0.1.
   # We should avoid the versions that is not compatible with the hacking,
@@ -31,8 +35,6 @@ dev = [
   # - Using Black with other tools - Black 25.1.0 documentation
   #   https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#bugbear
   "flake8-bugbear",
-  # To use flake8 --radon-show-closures
-  "flake8-polyfill",
   # To use pyproject.toml for Flake8 configuration
   "Flake8-pyproject",
   # Latest hacking depends on legacy version of flake8, and legacy hacking doesn't narrow flake8 version.
@@ -49,16 +51,15 @@ dev = [
   "pytest-mock",
   "pytest-resource-path",
   "pyvelocity",
-  "radon",
   "requests-mock",
   "ruff>=0.0.17",
-  "semgrep",
+  "semgrep; python_version < '3.10'",
+  "semgrep>=1.163.0; python_version >= '3.10'",
   "tomli",
   "types-freezegun",
   "types-invoke",
   "types-requests",
   "types-setuptools",
-  "xenon",
 ]
 
 
@@ -93,6 +94,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Internet",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Internet :: WWW/HTTP :: Indexing/Search",
@@ -252,15 +254,14 @@ markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
 ]
 
-[tool.radon]
-cc_min = "B"
-show_complexity = true
-show_mi = true
-
 [tool.ruff]
 line-length = 119
 
 [tool.ruff.lint]
+external = [
+    "DUO",  # dlint
+    "H",  # Openstack/hacking
+]
 select = ["ALL"]
 ignore = [
     # lint.pydocstyle
@@ -289,6 +290,11 @@ unfixable = [
 [tool.ruff.lint.isort]
 # To follow H301: Do not import more than one module per line (*) in Flake8 + openstack/hacking
 force-single-line = true
+
+[tool.ruff.lint.mccabe]
+# The default value: 10 is too loose,
+# 5 is as same as the default value of Radon for A rank that we use without any problems for a decade.
+max-complexity = 5
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101"]

--- a/radikopodcast/exceptions.py
+++ b/radikopodcast/exceptions.py
@@ -1,5 +1,9 @@
 """This module implements exceptions for this package."""
 
+# This comment avoids docformatter's issue:
+# - The docformatter removes blank line against PEP8 (conflicts with Ruff (Black)) · Issue #350 · PyCQA/docformatter
+#   https://github.com/PyCQA/docformatter/issues/350
+
 
 class Error(Exception):
     """Base class for exceptions in this module.

--- a/radikopodcast/programaggregate/segment/discovery.py
+++ b/radikopodcast/programaggregate/segment/discovery.py
@@ -51,8 +51,12 @@ class MediaPlaylistText:
         return [datetime.strptime(m.group(1), "%Y%m%d_%H%M%S").replace(tzinfo=JST) for m in matches]
 
 
+# Reason: docformatter's bug:
+# - The docformatter removes blank line against PEP8 (conflicts with Ruff (Black)) · Issue #350 · PyCQA/docformatter
+#   https://github.com/PyCQA/docformatter/issues/350
 async def fetch_media_playlist_text(master_playlist: MasterPlaylist) -> MediaPlaylistText:
-    """Fetches media playlist text from the URL in master_playlist using aiohttp."""
+    """Fetches media playlist text from the URL in master_playlist using aiohttp."""  # noqa: D202
+
     async with (
         aiohttp.ClientSession() as session,
         session.get(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from datetime import date
 from datetime import datetime
 from pathlib import Path
 from shutil import copyfile
+from textwrap import dedent
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
@@ -83,12 +84,16 @@ def xml_station(resource_path_root: Path) -> str:
     return (resource_path_root / "station.xml").read_text(encoding="utf-8")
 
 
+XML_STATION_NAME_LACKED = dedent("""\
+    <stations area_id="JP13" area_name="TOKYO JAPAN">
+    <station><id>TBS</id></station>
+    </stations>
+""")
+
+
 @pytest.fixture
 def xml_station_name_lacked() -> str:
-    return """\
-<stations area_id="JP13" area_name="TOKYO JAPAN">
-<station><id>TBS</id></station>
-</stations>"""
+    return XML_STATION_NAME_LACKED
 
 
 @pytest.fixture

--- a/tests/test_radiko_timefree30_archiver.py
+++ b/tests/test_radiko_timefree30_archiver.py
@@ -27,16 +27,14 @@ if TYPE_CHECKING:
 
     from radikopodcast.database.models import Program
 
-_PLAYLIST_TEXT = dedent(
-    """\
-        #EXTM3U
-        #EXTINF:5,
-        https://example.com/20210116_050000_FMJ_001.aac
-        #EXTINF:5,
-        https://example.com/20210116_050005_FMJ_001.aac
-        #EXT-X-ENDLIST
-    """,
-)
+_PLAYLIST_TEXT = dedent("""\
+    #EXTM3U
+    #EXTINF:5,
+    https://example.com/20210116_050000_FMJ_001.aac
+    #EXTINF:5,
+    https://example.com/20210116_050005_FMJ_001.aac
+    #EXT-X-ENDLIST
+""")
 
 
 @pytest.fixture
@@ -81,14 +79,12 @@ class TestGetSegmentDatetimes:
     @pytest.mark.usefixtures("mock_master_playlist_client")
     async def test_ignores_non_aac_lines(self, mocker: MockFixture) -> None:
         """Should skip comment lines and non-AAC URLs."""
-        playlist = dedent(
-            """\
-                #EXTM3U
-                #EXT-X-TARGETDURATION:5
-                https://example.com/20210116_050000_FMJ_001.aac
-                #EXT-X-ENDLIST
-            """,
-        )
+        playlist = dedent("""\
+            #EXTM3U
+            #EXT-X-TARGETDURATION:5
+            https://example.com/20210116_050000_FMJ_001.aac
+            #EXT-X-ENDLIST
+        """)
         mock_response = AsyncMock()
         mock_response.raise_for_status = MagicMock()
         mock_response.text = AsyncMock(return_value=playlist)


### PR DESCRIPTION
## Summary

- Add Python 3.14 support (classifiers, CI matrix, `docformatter>=1.7.8` pin to avoid removed `ast.Constant.s`)
- Replace `radon`/`xenon` with Ruff's McCabe complexity check (`max-complexity = 5`) and disable xenon in reusable lint workflow
- Pin `semgrep>=1.163.0` for Python ≥ 3.10; remove `flake8-polyfill`
- Add `permissions: contents/packages: read` to CI workflows (Principle of Least Privilege)
- Bump base Docker image to `20260515203000`; add `uv` build cache mount; remove explicit `--python 3.13` and unused `ENTRYPOINT`/`CMD`
- Work around [docformatter#350](https://github.com/PyCQA/docformatter/issues/350) (blank-line conflict with Ruff/Black) via `# noqa: D202` and a guard comment
- Declare Ruff `external` codes (`DUO`, `H`) to suppress unknown-rule warnings
- Clean up `dedent()` call style in tests; extract `XML_STATION_NAME_LACKED` as a module-level constant
- Remove unused `entrypoint: []` from devcontainer compose