### PR TITLE
Fix bug that program is not saved when Radiko API is slow

### DIFF
--- a/radikopodcast/database/program_downloader.py
+++ b/radikopodcast/database/program_downloader.py
@@ -8,6 +8,8 @@ from datetime import timedelta
 from logging import getLogger
 from typing import TYPE_CHECKING
 
+from radikoplaylist.exceptions import HttpRequestError
+
 from radikopodcast.database.models import Program
 from radikopodcast.radiko_datetime import RadikoDatetime
 from radikopodcast.radikoapi.radiko_api import RadikoApi
@@ -42,8 +44,11 @@ class ProgramDownloader:
         for target_date in self.daterange(self.time_free_oldest_date, self.time_free_day_before_newest_date):
             self.logger.debug("target_date = %04d-%02d-%02d", target_date.year, target_date.month, target_date.day)
             if Program.is_empty(target_date):
-                element_tree_radiko = RadikoApi(area_id=self.area_id).get_program(target_date)
-                Program.save_all(XmlConverterProgram(target_date, element_tree_radiko, self.area_id).to_model())
+                try:
+                    element_tree_radiko = RadikoApi(area_id=self.area_id).get_program(target_date)
+                    Program.save_all(XmlConverterProgram(target_date, element_tree_radiko, self.area_id).to_model())
+                except HttpRequestError:
+                    self.logger.exception("Failed to fetch/save programs for %s; will retry next cycle", target_date)
 
     @staticmethod
     def daterange(start_date: date, end_date: date) -> Generator[date, None, None]:

--- a/tests/database/test_program_downloader.py
+++ b/tests/database/test_program_downloader.py
@@ -1,0 +1,47 @@
+"""Tests for program_downloader.py."""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+from freezegun import freeze_time
+from pytest_mock import MockerFixture
+from radikoplaylist.exceptions import HttpRequestTimeoutError
+
+from radikopodcast.database.models import Program
+from radikopodcast.database.program_downloader import ProgramDownloader
+from radikopodcast.radiko_datetime import JST
+from radikopodcast.radikoapi.radiko_api import RadikoApi
+
+
+class TestProgramDownloader:
+    """Tests for ProgramDownloader."""
+
+    @staticmethod
+    @pytest.mark.usefixtures("database_session_with_schema", "_mock_requests_station")
+    @freeze_time("2021-01-17 20:00:00", tz_offset=+9)
+    def test_download_all_time_free_programs_continues_after_api_timeout(mocker: MockerFixture) -> None:
+        """A timeout on one date must not abort other dates or raise to caller."""
+        now = datetime(2021, 1, 17, 20, 0, 0, tzinfo=JST)
+        downloader = ProgramDownloader(now)
+
+        fake_xml = MagicMock()
+        timeout_day = 14
+        number_of_dates_in_range = 7  # Jan 10-16
+        expected_save_count = number_of_dates_in_range - 1  # one date times out
+
+        def get_program_side_effect(target_date: datetime) -> str:
+            if target_date.day == timeout_day:
+                msg = "simulated timeout"
+                raise HttpRequestTimeoutError(msg)
+            return fake_xml
+
+        mocker.patch.object(RadikoApi, "get_program", side_effect=get_program_side_effect)
+        mocker.patch.object(Program, "is_empty", return_value=True)
+        mock_save_all = mocker.patch.object(Program, "save_all")
+        mocker.patch("radikopodcast.database.program_downloader.XmlConverterProgram")
+
+        # Must not raise despite the timeout on Jan 14
+        downloader.download_all_time_free_programs()
+
+        assert mock_save_all.call_count == expected_save_count


### PR DESCRIPTION
## Summary

- Catch `HttpRequestError` per-date in `ProgramDownloader.download_all_time_free_programs()` so a slow or unreachable Radiko schedule API does not abort the remaining dates or crash the process.

## Background

The Radiko schedule API (`/v3/program/date/YYYYMMDD/JP13.xml`) is fetched once per day, just after the 5:00 AM JST daily update — exactly when the API is under peak load. If any single date's request exceeded the 20-second timeout, `HttpRequestTimeoutError` was raised and propagated all the way out of `archive_repeatedly()`, terminating the process. Programs for the timed-out date were never written to the database and therefore never archived.

## Changes

- **`radikopodcast/database/program_downloader.py`** — wrap the `get_program` / `save_all` call pair in a `try/except HttpRequestError` block. On failure the error is logged with a full traceback and the loop continues to the next date. Because `Program.is_empty()` still returns `True` for the failed date, it is automatically retried on the next 3-minute loop cycle.
  - `HttpRequestError` is the `radikoplaylist` base class that covers both `HttpRequestTimeoutError` (timeout) and `BadHttpStatusCodeError` (non-200), keeping the catch specific enough to avoid masking unrelated bugs.
