### PR TITLE
Handle NoAvailableUrlError and ConnectionError gracefully in archive workflow

### DIFF
--- a/radikopodcast/archive_workflow.py
+++ b/radikopodcast/archive_workflow.py
@@ -8,10 +8,20 @@ from logging import getLogger
 from typing import TYPE_CHECKING
 
 from radikoplaylist.exceptions import BadHttpStatusCodeError
+from radikoplaylist.exceptions import NoAvailableUrlError
+from requests.exceptions import ConnectionError as RequestsConnectionError
 
 if TYPE_CHECKING:
     from radikopodcast.database.models import Program
     from radikopodcast.programaggregate.factory import RadikoProgramAggregateToArchiveFactory
+
+_ARCHIVE_ERROR_MESSAGES: dict[type[Exception], str] = {
+    BadHttpStatusCodeError: (
+        "HTTP error archiving %s %s — station may not support this time-free type; marking failed."
+    ),
+    NoAvailableUrlError: "No available playlist URL for %s %s — URL may be unsupported; marking failed.",
+    RequestsConnectionError: "Connection error archiving %s %s — Radiko API unreachable; marking failed.",
+}
 
 
 class RadikoArchiveWorkflow:
@@ -37,8 +47,20 @@ class RadikoArchiveWorkflow:
             program.ft,
             program.to,
         )
+        program.mark_archiving()
         try:
-            program.mark_archiving()
+            await self._try_archive(program)
+        except FileExistsError:
+            if self.stop_if_file_exists:
+                raise
+            program.mark_failed()
+            return
+        except (BadHttpStatusCodeError, NoAvailableUrlError, RequestsConnectionError):
+            return
+        program.mark_archived()
+
+    async def _try_archive(self, program: Program) -> None:
+        try:
             radiko_program_aggregate = self.radiko_program_aggregate_factory.create(program)
             await radiko_program_aggregate.archive()
         except (KeyboardInterrupt, asyncio.CancelledError):
@@ -46,17 +68,11 @@ class RadikoArchiveWorkflow:
             self.logger.debug("FFmpeg run cancelled.")
             program.mark_suspended()
             raise
-        except FileExistsError:
-            if self.stop_if_file_exists:
-                raise
-            program.mark_failed()
-            return
-        except BadHttpStatusCodeError:
+        except (BadHttpStatusCodeError, NoAvailableUrlError, RequestsConnectionError) as error:
             self.logger.warning(
-                "HTTP error archiving %s %s — station may not support this time-free type; marking failed.",
+                _ARCHIVE_ERROR_MESSAGES[type(error)],
                 program.station_id,
                 program.ft_string,
             )
             program.mark_failed()
-            return
-        program.mark_archived()
+            raise

--- a/tests/test_radiko_archiver.py
+++ b/tests/test_radiko_archiver.py
@@ -7,6 +7,8 @@ from unittest.mock import AsyncMock
 import pytest
 from asynccpu.process_task_pool_executor import ProcessTaskPoolExecutor
 from pytest_mock import MockFixture
+from radikoplaylist.exceptions import NoAvailableUrlError
+from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from radikopodcast.archive_workflow import RadikoArchiveWorkflow
 from radikopodcast.database.models import Program
@@ -71,3 +73,27 @@ class TestRadikoArchiver:
         await radiko_archive_workflow.execute(program)
         mock_archive.assert_called_once()
         assert radiko_archive_workflow.radiko_program_aggregate_factory.radiko_session == "session_token"
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("record_program")
+    async def test_no_available_url_skip(self, mocker: MockFixture) -> None:
+        """NoAvailableUrlError should mark program as failed without raising."""
+        mocker.patch.object(
+            RadikoProgramAggregateToArchiveFactory,
+            "create",
+            side_effect=NoAvailableUrlError([]),
+        )
+        program = Program.find(["ROPPONGI PASSION PIT"])[0]
+        await RadikoArchiveWorkflow(RadikoProgramAggregateToArchiveFactory(OutputDirectory())).execute(program)
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("record_program")
+    async def test_connection_error_skip(self, mocker: MockFixture) -> None:
+        """RequestsConnectionError should mark program as failed without raising."""
+        mocker.patch.object(
+            RadikoProgramAggregateToArchiveFactory,
+            "create",
+            side_effect=RequestsConnectionError(),
+        )
+        program = Program.find(["ROPPONGI PASSION PIT"])[0]
+        await RadikoArchiveWorkflow(RadikoProgramAggregateToArchiveFactory(OutputDirectory())).execute(program)


### PR DESCRIPTION
## Summary

- Add `NoAvailableUrlError` and `requests.ConnectionError` to the set of recoverable archive errors, marking the program as failed instead of crashing
- Extract `_try_archive` method to separate archiving logic from program status transitions (`mark_archiving` / `mark_archived`)
- Consolidate per-exception warning messages into `_ARCHIVE_ERROR_MESSAGES` lookup table to avoid repetition

## Motivation

The Radiko API can return no playlist URL for certain stations or content types, and network connectivity issues can raise `ConnectionError`. Previously these propagated uncaught, interrupting the archive workflow for all remaining programs. Both are now treated as non-fatal and the program is marked `FAILED`.
