### PR TITLE
Development settings

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,14 +20,20 @@ on:
   schedule:
     - cron: '44 6 * * 2'
 
+permissions:
+  # required for all workflows
+  security-events: write
+  # required to fetch internal or private CodeQL packs
+  packages: read
+  # only required for workflows in private repositories
+  actions: read
+  contents: read
+
 jobs:
   call-workflow:
+    uses: yukihiko-shinoda/reusable-workflow-codeql-python/.github/workflows/workflow.yml@ca5a2fbce666756cb15aca6e3a33852588728909  # v1.0.0
     permissions:
-      # required for all workflows
       security-events: write
-      # required to fetch internal or private CodeQL packs
       packages: read
-      # only required for workflows in private repositories
       actions: read
       contents: read
-    uses: yukihiko-shinoda/invoke-lint/.github/workflows/reusable-codeql-analysis.yml@main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,10 +3,9 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 permissions:
-  contents: read  # Advanced Security suggested for Principle of Least Privilege in pull request review
-  packages: read  # Advanced Security suggested for Principle of Least Privilege in pull request review
+  contents: read
 jobs:
   call-workflow:
-    uses: yukihiko-shinoda/invoke-lint/.github/workflows/reusable-deploy.yml@main
+    uses: yukihiko-shinoda/reusable-workflow-invoke-lint-deploy/.github/workflows/workflow.yml@eab497a87ebe0cc07a02f723660b750be925f4aa  # v1.0.0
     secrets:
       pypi_password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/qlty.yml
+++ b/.github/workflows/qlty.yml
@@ -2,9 +2,15 @@ on:
   push:
     branches:
       - main
+# For OIDC token exchange with Qlty:
+# - Configuring OpenID Connect in cloud providers - GitHub Docs
+#   https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-cloud-providers#adding-permissions-settings
+permissions:
+  contents: read
+  id-token: write
 jobs:
   call-workflow:
+    uses: yukihiko-shinoda/reusable-workflow-invoke-lint-qlty/.github/workflows/workflow.yml@732676e4d8cea832b97f2f66ee73fd65fa837e7d  # v1.0.0
     permissions:
       contents: read
       id-token: write
-    uses: yukihiko-shinoda/invoke-lint/.github/workflows/reusable-qlty.yml@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,14 +7,11 @@ on:
     branches:
       - main
 permissions:
-  contents: read  # Advanced Security suggested for Principle of Least Privilege in pull request review
-  packages: read  # Advanced Security suggested for Principle of Least Privilege in pull request review
+  contents: read
 jobs:
   call-workflow-test:
-    uses: yukihiko-shinoda/invoke-lint/.github/workflows/reusable-test.yml@main
+    uses: yukihiko-shinoda/reusable-workflow-invoke-lint-test/.github/workflows/workflow.yml@3deca6708b4c2b623c7eac175a63973c05c64e3b  # v1.0.0
     with:
       support-python-versions: "[ '3.14', '3.13', '3.12', '3.11', '3.10', '3.9' ]"
   call-workflow-lint:
-    uses: yukihiko-shinoda/invoke-lint/.github/workflows/reusable-lint.yml@main
-    with:
-      enable-xenon: false
+    uses: yukihiko-shinoda/reusable-workflow-invoke-lint-lint/.github/workflows/workflow.yml@0966c64de69c044585bbdca96980a8393c761829  # v1.0.0

--- a/compose.yml
+++ b/compose.yml
@@ -4,6 +4,7 @@ services:
       context: .
     image: mstmelody/radiko-podcast:development
     volumes:
+      - ~/.claude:/root/.claude:cached
       - ./config.yml:/workspace/config.yml
       - ./output:/workspace/output
       # - Using uv in Docker | uv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,64 +4,54 @@ build-backend = "setuptools.build_meta"
 
 [dependency-groups]
 dev = [
-  "bandit",
-  "build",
   "bump-my-version",
-  "cohesion",
-  # The coverage==3.5.3 is difficult to analyze its dependencies by dependencies management tool,
-  # so we should avoid 3.5.3 or lower.
-  # - Command: "pipenv install --skip-lock" fails 
-  #   since it tries to parse legacy package metadata and raise InstallError
-  #   · Issue #5595 · pypa/pipenv
-  #   https://github.com/pypa/pipenv/issues/5595
-  "coverage>=3.5.4",
-  # The dlint less than 0.14.0 limits max version of flake8.
-  # - dlint/requirements.txt at 0.13.0 · dlint-py/dlint
-  #   https://github.com/dlint-py/dlint/blob/0.13.0/requirements.txt#L1
-  "dlint>=0.14.0",
-  # We exclude docformatter versions before 1.7.8 because they depend on untokenize==0.1.1,
-  # whose setup.py uses ast.Constant.s that was removed in Python 3.14.
-  # docformatter 1.7.8 and later require Python 3.10 or later instead of untokenize.
-  # And, we specify as follows if the latest supported Python version is less than 3.11,
-  # so that docformatter can read the settings in pyproject.toml:
-  "docformatter[tomli]>=1.7.8; python_version < '3.11' and python_version >= '3.10'",
-  "docformatter>=1.7.8; python_version >= '3.11'",
-  "dodgy",
-  # The hacking depends flake8 ~=6.1.0 or ~=5.0.1 or ~=4.0.1.
-  # We should avoid the versions that is not compatible with the hacking,
-  # considering the speed of dependency calculation process
-  "flake8!=6.0.0,!=5.0.0,>=4.0.1",
-  # To replace E501 in pycodestyle with B950 in flake8-bugbear:
-  # - Using Black with other tools - Black 25.1.0 documentation
-  #   https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#bugbear
-  "flake8-bugbear",
-  # To use pyproject.toml for Flake8 configuration
-  "Flake8-pyproject",
-  # Latest hacking depends on legacy version of flake8, and legacy hacking doesn't narrow flake8 version.
-  # When unpin hacking, it has possibility to install too legacy version of hacking.
-  "hacking>=5.0.0",
-  "invokelint>=0.8.1",
+  "invokelint[basic]>=0.19.0",
   "jinja2",
-  "mypy",
   "numpy",
-  "pylint",
-  "pytest",
   "pytest-asyncio",
   "pytest-freezegun",
   "pytest-mock",
   "pytest-resource-path",
   "pyvelocity",
   "requests-mock",
-  "ruff>=0.0.17",
-  "semgrep; python_version < '3.10'",
-  "semgrep>=1.163.0; python_version >= '3.10'",
+  # To prevent following error when uv lock:
+  #   × Failed to build `semgrep==0.86.3`
+  # ├─▶ The build backend returned an error
+  # ╰─▶ Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
+
+  #     [stderr]
+  #     Traceback (most recent call last):
+  #       File "<string>", line 14, in <module>
+  #         requires = get_requires_for_build({})
+  #       File "/root/.cache/uv/builds-v0/.tmpYdUb3N/lib/python3.14/site-packages/setuptools/build_meta.py", line 333, in get_requires_for_build_wheel
+  #         return self._get_build_requires(config_settings, requirements=[])
+  #                ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  #       File "/root/.cache/uv/builds-v0/.tmpYdUb3N/lib/python3.14/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
+  #         self.run_setup()
+  #         ~~~~~~~~~~~~~~^^
+  #       File "/root/.cache/uv/builds-v0/.tmpYdUb3N/lib/python3.14/site-packages/setuptools/build_meta.py", line 520, in run_setup
+  #         super().run_setup(setup_script=setup_script)
+  #         ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  #       File "/root/.cache/uv/builds-v0/.tmpYdUb3N/lib/python3.14/site-packages/setuptools/build_meta.py", line 317, in run_setup
+  #         exec(code, locals())
+  #         ~~~~^^^^^^^^^^^^^^^^
+  #       File "<string>", line 94, in <module>
+  #       File "<string>", line 72, in find_executable
+  #     Exception: Could not find 'semgrep-core' executable, tried 'SEMGREP_CORE_BIN' and system 'semgrep-core'
+  # If we simply lock as "semgrep; python_version >= '3.9' or python_version>='3.6' and platform_system=='Linux'",
+  # the semgrep 1.121.0 is installed in Python 3.14 and cause following error:
+  #     File "/root/.local/share/uv/python/cpython-3.14.5-linux-aarch64-gnu/lib/python3.14/importlib/__init__.py", line 88, in import_module
+  #       return _bootstrap._gcd_import(name[level:], package, level)
+  #              ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  #   TypeError: Metaclasses with custom tp_new are not supported.
+  "semgrep>=0.87.0; python_version < '3.10' or platform_system=='Linux'",
+  "semgrep>=1.122.0; python_version >= '3.10'",
   "tomli",
+  "types-defusedxml;python_version>='3.8'",
   "types-freezegun",
-  "types-invoke",
   "types-requests",
   "types-setuptools",
 ]
-
 
 [project]
 name = "radikopodcast"
@@ -71,41 +61,41 @@ readme = "README.md"
 requires-python = ">=3.9"
 license = {file = "LICENSE"}
 keywords = [
-    "radiko",
-    "radikopodcast",
+  "radiko",
+  "radikopodcast",
 ]
 authors = [
-    {name = "Master", email = "roadmasternavi@gmail.com"},
+  {name = "Master", email = "roadmasternavi@gmail.com"},
 ]
 maintainers = [
-    {name = "Master", email = "roadmasternavi@gmail.com"},
+  {name = "Master", email = "roadmasternavi@gmail.com"},
 ]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Environment :: Console",
-    "Intended Audience :: End Users/Desktop",
-    "License :: OSI Approved :: MIT License",
-    "Natural Language :: English",
-    "Operating System :: OS Independent",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
-    "Topic :: Internet",
-    "Topic :: Internet :: WWW/HTTP",
-    "Topic :: Internet :: WWW/HTTP :: Indexing/Search",
-    "Topic :: Multimedia",
-    "Topic :: Multimedia :: Sound/Audio",
-    "Topic :: Multimedia :: Sound/Audio :: Capture/Recording",
-    "Topic :: System",
-    "Topic :: System :: Archiving",
-    "Topic :: System :: Archiving :: Backup",
-    "Topic :: System :: Filesystems",
-    "Typing :: Typed",
+  "Development Status :: 5 - Production/Stable",
+  "Environment :: Console",
+  "Intended Audience :: End Users/Desktop",
+  "License :: OSI Approved :: MIT License",
+  "Natural Language :: English",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Topic :: Internet",
+  "Topic :: Internet :: WWW/HTTP",
+  "Topic :: Internet :: WWW/HTTP :: Indexing/Search",
+  "Topic :: Multimedia",
+  "Topic :: Multimedia :: Sound/Audio",
+  "Topic :: Multimedia :: Sound/Audio :: Capture/Recording",
+  "Topic :: System",
+  "Topic :: System :: Archiving",
+  "Topic :: System :: Archiving :: Backup",
+  "Topic :: System :: Filesystems",
+  "Typing :: Typed",
 ]
 dependencies = [
   # To request in asynchronously to archive Time Free 30 programs efficiently
@@ -171,13 +161,13 @@ replace = '__version__ = "{new_version}"'
 
 [tool.coverage.report]
 exclude_also = [
-    # Assume `if TYPE_CHECKING: ... else: ...` block is covered · Issue #831 · nedbat/coveragepy
-    #   https://github.com/nedbat/coveragepy/issues/831#issuecomment-517778185
-    "if TYPE_CHECKING:",
-    # Pylint will detect instead:
-    # - abstract-method / W0223 - Pylint 2.17.0-dev0 documentation
-    #   https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/abstract-method.html
-    "raise NotImplementedError",
+  # Assume `if TYPE_CHECKING: ... else: ...` block is covered · Issue #831 · nedbat/coveragepy
+  #   https://github.com/nedbat/coveragepy/issues/831#issuecomment-517778185
+  "if TYPE_CHECKING:",
+  # Pylint will detect instead:
+  # - abstract-method / W0223 - Pylint 2.17.0-dev0 documentation
+  #   https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/abstract-method.html
+  "raise NotImplementedError",
 ]
 
 [tool.docformatter]
@@ -220,16 +210,16 @@ strict = true
 
 [[tool.mypy.overrides]]
 module = [
-    "defusedxml.*",
-    "ffmpeg",
-    "inflector",
+  "defusedxml.*",
+  "ffmpeg",
+  "inflector",
 ]
 ignore_missing_imports = true
 
 [tool.pylint]
 disable = [
-    # We check line length by flake8-bugbear B950.
-    "line-too-long",
+  # We check line length by flake8-bugbear B950.
+  "line-too-long",
 ]
 
 [tool.pylint.basic]
@@ -246,12 +236,12 @@ min-public-methods = "1"
 
 [tool.pylint.typecheck]
 ignored-classes = [
-    "scoped_session",  # @see https://stackoverflow.com/questions/59214324/flask-error-db-scoped-session-instance-of-scoped-session-has-no-commit-mem/59214469#59214469
+  "scoped_session",  # @see https://stackoverflow.com/questions/59214324/flask-error-db-scoped-session-instance-of-scoped-session-has-no-commit-mem/59214469#59214469
 ]
 
 [tool.pytest.ini_options]
 markers = [
-    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+  "slow: marks tests as slow (deselect with '-m \"not slow\"')",
 ]
 
 [tool.ruff]
@@ -259,32 +249,38 @@ line-length = 119
 
 [tool.ruff.lint]
 external = [
-    "DUO",  # dlint
-    "H",  # Openstack/hacking
+  "DUO",  # dlint
+  "H",    # Openstack/hacking
 ]
-select = ["ALL"]
+select = [
+  "ALL",
+  # Since compatible with PEP257, we can check docstring style by Ruff and don't need to consider about docstring style separately:
+  # - Should the first line of a Python function docstring be in imperative mood? (ruff / pydocstyle D401)
+  #   https://zenn.dev/y_shinoda/articles/pydocstyle-d401
+  "D401",    # First line should be in imperative mood
+]
 ignore = [
-    # lint.pydocstyle
-    # Reason: Docstring may be missed since docstring-min-length is set.
-    "D101",    # Missing docstring in public class
-    "D102",    # Missing docstring in public method
-    "D103",    # Missing docstring in public function
-    "D105",    # Missing docstring in magic method
-    "D106",    # Missing docstring in public nested class
-    "D107",    # Missing docstring in __init__
-    # Reason: First line may ends with ":" for expression.
-    "D400",   # First line should end with a period
-    # Reason: First line may ends with function signature for expression.
-    "D402",    # First line should not be the function’s “signature”
-    # Reason: First line may ends with ":" for expression.
-    "D415",    # First line should end with a period, question mark, or exclamation point
-    # Reason: `Line too long` is checked by flake8-bugbear.
-    "E501",    # Line too long ({width} > {limit})
+  # lint.pydocstyle
+  # Reason: Docstring may be missed since docstring-min-length is set.
+  "D101",    # Missing docstring in public class
+  "D102",    # Missing docstring in public method
+  "D103",    # Missing docstring in public function
+  "D105",    # Missing docstring in magic method
+  "D106",    # Missing docstring in public nested class
+  "D107",    # Missing docstring in __init__
+  # Reason: First line may ends with ":" for expression.
+  "D400",   # First line should end with a period
+  # Reason: First line may ends with function signature for expression.
+  "D402",    # First line should not be the function’s “signature”
+  # Reason: First line may ends with ":" for expression.
+  "D415",    # First line should end with a period, question mark, or exclamation point
+  # Reason: `Line too long` is checked by flake8-bugbear.
+  "E501",    # Line too long ({width} > {limit})
 ]
 unfixable = [
-    # When fix `return a and b != ""` as `return a and b`, mypy will report warning:
-    #   error: Incompatible return value type (got "Union[Literal[False], str]", expected "bool")  [return-value]
-    "PLC1901",
+  # When fix `return a and b != ""` as `return a and b`, mypy will report warning:
+  #   error: Incompatible return value type (got "Union[Literal[False], str]", expected "bool")  [return-value]
+  "PLC1901",
 ]
 
 [tool.ruff.lint.isort]

--- a/radikopodcast/archive_workflow.py
+++ b/radikopodcast/archive_workflow.py
@@ -38,7 +38,7 @@ class RadikoArchiveWorkflow:
         self.stop_if_file_exists = stop_if_file_exists
 
     async def execute(self, program: Program) -> None:
-        """Archives radiko program."""
+        """Archive radiko program."""
         self.logger.debug("Start archive")
         self.logger.debug(
             "program time: %s, station: %s, start: %s, end: %s",

--- a/radikopodcast/database/database.py
+++ b/radikopodcast/database/database.py
@@ -20,6 +20,6 @@ class Database:
 
     @staticmethod
     def initialize_database() -> None:
-        """This function create empty tables from SQLAlchemy models."""
+        """Create empty tables from SQLAlchemy models."""
         # pylint: disable=no-member
         Base.metadata.create_all(Session.get_bind(), checkfirst=False)

--- a/radikopodcast/database/models.py
+++ b/radikopodcast/database/models.py
@@ -84,7 +84,7 @@ class ModelInitByXml(Base, Generic[TypeVarXmlParser]):
 
     @classmethod
     def save_all(cls, models: Iterable[TypeVarModelInitByXml]) -> None:
-        """This method insert Store models into database."""
+        """Insert all models into the database."""
         with SessionManager() as session, session.begin():
             session.add_all(models)
 
@@ -113,7 +113,7 @@ class Station(ModelInitByXml[XmlParserStation]):
 
     @staticmethod
     def is_empty() -> bool:
-        """Returns whether the station table is empty."""
+        """Return whether the station table is empty."""
         with SessionManager() as session:
             # Reason: Pylint's bug:
             # - `not-callable` false positive for class · Issue #8138 · pylint-dev/pylint
@@ -201,7 +201,7 @@ class Program(ModelInitByXml[XmlParserProgram]):
 
     @staticmethod
     def find(keywords: list[str]) -> list[Program]:
-        """This method select Store model from database."""
+        """Select programs from the database matching keywords."""
         with SessionManager() as session:
             list_condition_keyword = [Program.title.like(f"%{keyword}%") for keyword in keywords]
             return (
@@ -219,7 +219,7 @@ class Program(ModelInitByXml[XmlParserProgram]):
             session.query(Program).filter(Program.date < boundary_date).delete()
 
     def is_timefree30_required(self) -> bool:
-        """Returns whether the program requires time-free 30-day download."""
+        """Return whether the program requires time-free 30-day download."""
         if not self.ft:
             message = f"{self.ft=}"
             raise ValueError(message)

--- a/radikopodcast/database/program_schedule.py
+++ b/radikopodcast/database/program_schedule.py
@@ -52,7 +52,7 @@ class ProgramSchedule:
         )
 
     def add(self, now: datetime) -> None:
-        """Adds programs from radiko API."""
+        """Add programs from radiko API."""
         program_downloader = ProgramDownloader(now, area_id=self.area_id, radiko_session=self.radiko_session)
         program_downloader.download_all_time_free_programs()
 

--- a/radikopodcast/output_directory.py
+++ b/radikopodcast/output_directory.py
@@ -18,7 +18,7 @@ class OutputDirectory:
         self.path.mkdir(exist_ok=True)
 
     async def get_output_file_path(self, program: Program) -> anyio.Path:
-        """Returns output file path for the given program."""
+        """Return output file path for the given program."""
         file_name = f"{self.build_file_stem(program)}.m4a"
         output_file_path = anyio.Path(self.path) / file_name
         self.logger.debug("out file name: %s", output_file_path)
@@ -30,5 +30,5 @@ class OutputDirectory:
 
     @staticmethod
     def build_file_stem(program: Program) -> str:
-        """Builds file stem for the given program."""
+        """Build file stem for the given program."""
         return f"{program.ft_string}_{program.station_id}_{sanitize_filename(str(program.title))}"

--- a/radikopodcast/programaggregate/factory.py
+++ b/radikopodcast/programaggregate/factory.py
@@ -51,7 +51,7 @@ class RadikoProgramAggregateToArchiveFactory:
         )
 
     def _is_fast_api(self, program: Program) -> bool:
-        """Returns True if the station's playlist URL is served from https://radiko.jp (fast CDN).
+        """Return True if the station's playlist URL is served from https://radiko.jp (fast CDN).
 
         Uses MasterPlaylistClient.get() so tests can mock at the same level as the rest of the
         archiving pipeline.

--- a/radikopodcast/programaggregate/segment/discovery.py
+++ b/radikopodcast/programaggregate/segment/discovery.py
@@ -41,12 +41,12 @@ class MediaPlaylistText:
         self.string = string
 
     def analyze_urls(self) -> Generator[str]:
-        """Parses segment datetimes from AAC URLs in media playlist text."""
+        """Parse AAC URLs in the media playlist and yield non-comment lines."""
         lines = (line.strip() for line in self.string.splitlines())
         return (line for line in lines if line and not line.startswith("#"))
 
     def analyze_segment_datetimes(self) -> list[datetime]:
-        """Parses segment datetimes from AAC URLs in media playlist text."""
+        """Parse segment datetimes from AAC URLs in the media playlist text."""
         matches = (match for url in self.analyze_urls() if (match := self.AAC_SEGMENT_PATTERN.search(url)))
         return [datetime.strptime(m.group(1), "%Y%m%d_%H%M%S").replace(tzinfo=JST) for m in matches]
 
@@ -55,7 +55,7 @@ class MediaPlaylistText:
 # - The docformatter removes blank line against PEP8 (conflicts with Ruff (Black)) · Issue #350 · PyCQA/docformatter
 #   https://github.com/PyCQA/docformatter/issues/350
 async def fetch_media_playlist_text(master_playlist: MasterPlaylist) -> MediaPlaylistText:
-    """Fetches media playlist text from the URL in master_playlist using aiohttp."""  # noqa: D202
+    """Fetch media playlist text from the URL in master_playlist using aiohttp."""  # noqa: D202
 
     async with (
         aiohttp.ClientSession() as session,
@@ -78,7 +78,7 @@ async def get_segment_datetimes(  # noqa: PLR0913 pylint: disable=too-many-argum
     radiko_session: str,
     request_factory: MasterPlaylistRequestFactory,
 ) -> list[datetime]:
-    """Fetches media playlist and returns the segment datetimes parsed from AAC URLs."""
+    """Fetch media playlist and return the segment datetimes parsed from AAC URLs."""
     master_playlist_request = request_factory(station_id, start_at, end_at)
     master_playlist = MasterPlaylistClient.get(master_playlist_request, area_id=area_id, radiko_session=radiko_session)
     text = await fetch_media_playlist_text(master_playlist)
@@ -106,7 +106,7 @@ class SegmentsDiscovery:
         return sorted({dt for result in results for dt in result})
 
     def create_chunks(self) -> list[tuple[datetime, datetime]]:
-        """Creates chunks of the program's time range to query for segments in parallel."""
+        """Create chunks of the program's time range to query for segments in parallel."""
         dt_start = datetime.strptime(self.program.ft_string, RadikoDatetime.FORMAT_CODE).replace(tzinfo=JST)
         dt_end = datetime.strptime(self.program.to_string, RadikoDatetime.FORMAT_CODE).replace(tzinfo=JST)
         chunk = timedelta(seconds=_INTERVAL_SECONDS)
@@ -119,7 +119,7 @@ class SegmentsDiscovery:
         return chunks
 
     async def gather_segment_datetimes(self) -> list[list[datetime]]:
-        """Fetches segment datetimes for all chunks in parallel using ProcessTaskPoolExecutor."""
+        """Fetch segment datetimes for all chunks in parallel using ProcessTaskPoolExecutor."""
         chunks = self.create_chunks()
         with ProcessTaskPoolExecutor(max_workers=_MAX_WORKERS, cancel_tasks_when_shutdown=True) as executor:
             awaitables = {

--- a/radikopodcast/programaggregate/segment/downloader.py
+++ b/radikopodcast/programaggregate/segment/downloader.py
@@ -50,7 +50,7 @@ class SegmentsDownloader:
         return await self.segment_dir.create_segment_list_file()
 
     async def download_segment(self, segment_dt: datetime) -> None:
-        """Downloads one 5-second segment as an .m4a file into segment_dir."""
+        """Download one 5-second segment as an .m4a file into segment_dir."""
         start_at = int(segment_dt.strftime(RadikoDatetime.FORMAT_CODE))
         end_at = int((segment_dt + timedelta(seconds=4)).strftime(RadikoDatetime.FORMAT_CODE))
         master_playlist_request = self.request_factory(self.station_id, start_at, end_at)

--- a/radikopodcast/programaggregate/slowapi.py
+++ b/radikopodcast/programaggregate/slowapi.py
@@ -39,7 +39,7 @@ class RadikoProgramAggregateToArchiveSlowApi(RadikoProgramAggregateToArchive):
         self.request_factory = request_factory
 
     async def archive(self) -> None:
-        """Archives a program via segment-by-segment download and ffmpeg concatenation."""
+        """Archive a program via segment-by-segment download and ffmpeg concatenation."""
         out_file = await self.output_directory.get_output_file_path(self.program)
         area_id = self.program.area_id
         if not area_id:

--- a/radikopodcast/radiko_datetime.py
+++ b/radikopodcast/radiko_datetime.py
@@ -44,7 +44,7 @@ class RadikoDatetime:
 
     @staticmethod
     def is_timefree30_required(program_ft: datetime) -> bool:
-        """Returns whether the program is available without time-free 30-day download."""
+        """Return whether the program requires time-free 30-day download."""
         time_free_oldest_date = RadikoDatetime.time_free_oldest_date(RadikoDatetime.now_jst())
         radiko_date_of_program_ft = RadikoDate.radiko_date(program_ft)
         return radiko_date_of_program_ft < time_free_oldest_date
@@ -65,7 +65,7 @@ class RadikoDate:
 
     @staticmethod
     def radiko_date(date_time: datetime) -> date:
-        """Returns the date of the program ft belongs to."""
+        """Return the radiko date that program_ft belongs to."""
         if date_time.hour < HOUR_BORDER_OF_RADIKO_DATE:
             return (date_time - timedelta(days=1)).date()
         return date_time.date()

--- a/radikopodcast/radiko_podcast.py
+++ b/radikopodcast/radiko_podcast.py
@@ -53,7 +53,7 @@ class RadikoPodcast:
         self.logger = logging.getLogger(__name__)
 
     def run(self) -> None:
-        """Runs."""
+        """Run the podcast archiver."""
         try:
             asyncio.run(self.archive_repeatedly())
         except Exception:
@@ -61,7 +61,7 @@ class RadikoPodcast:
             raise
 
     async def archive_repeatedly(self) -> None:
-        """Archives repeatedly."""
+        """Archive programs repeatedly on a schedule."""
         with ProcessTaskPoolExecutor(
             max_workers=CONFIG.number_process,
             cancel_tasks_when_shutdown=True,

--- a/radikopodcast/radiko_stream_spec_factory.py
+++ b/radikopodcast/radiko_stream_spec_factory.py
@@ -28,7 +28,7 @@ class RadikoStreamSpecFactory:
         self.logger = getLogger(__name__)
 
     async def create(self) -> "StreamSpec":
-        """Creates."""
+        """Create and return the FFmpeg StreamSpec for this program."""
         master_playlist_request = TimeFreeMasterPlaylistRequest(
             self.program.station_id,
             int(self.program.ft_string),

--- a/radikopodcast/radikoapi/radiko_api.py
+++ b/radikopodcast/radikoapi/radiko_api.py
@@ -34,5 +34,4 @@ class RadikoApi:
 
     @staticmethod
     def get(url: str) -> "Element":
-        # Reason: The defusedxml's responsible.
-        return ElementTree.fromstring(Requester.get(url).content, forbid_dtd=True)  # type: ignore[no-any-return]
+        return ElementTree.fromstring(Requester.get(url).content, forbid_dtd=True)

--- a/radikopodcast/radikoxml/xml_converter.py
+++ b/radikopodcast/radikoxml/xml_converter.py
@@ -31,7 +31,7 @@ class XmlConverter(Generic[T]):
         self.logger = getLogger(__name__)
 
     def to_model(self) -> list[T]:
-        """Converts to list of SQLAlchemy model of station of radiko."""
+        """Convert XML data to a list of SQLAlchemy models."""
         list_model = list(filter(lambda x: x is not None, self.comprehension_notation()))
         self.logger.debug(list_model)
         # Reason: mypy's bug, see: https://github.com/python/mypy/issues/6847

--- a/radikopodcast/radikoxml/xml_parser.py
+++ b/radikopodcast/radikoxml/xml_parser.py
@@ -38,7 +38,7 @@ class XmlParser:
         return bool(self.list_error)
 
     def stock_error(self, method: Callable[[], T], message: str) -> T | None:
-        """This method stocks error."""
+        """Collect any XmlParseError raised by method into list_error."""
         with MultipleErrorCollector(XmlParseError, message, self.list_error):
             return method()
         return None

--- a/radikopodcast/radikoxml/xml_parser.py
+++ b/radikopodcast/radikoxml/xml_parser.py
@@ -45,8 +45,7 @@ class XmlParser:
 
     @staticmethod
     def to_string(element: Element) -> str:
-        # Reason: The defusedxml's responsible.
-        return ElementTree.tostring(element, encoding="unicode")  # type: ignore[no-any-return]
+        return ElementTree.tostring(element, encoding="unicode")
 
 
 # Reason: This class converts argument of constructor to property. pylint: disable=too-few-public-methods

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -259,15 +259,13 @@ def _mock_requests_station(requests_mock: Mocker, xml_station: str) -> None:
 @pytest.fixture
 # Reason: To refer other fixture. pylint: disable=redefined-outer-name
 def element_tree_program(xml_program: str) -> Element:
-    # Reason: The defusedxml's responsible.
-    return ElementTree.fromstring(xml_program, forbid_dtd=True)  # type: ignore[no-any-return]
+    return ElementTree.fromstring(xml_program, forbid_dtd=True)
 
 
 @pytest.fixture
 # Reason: To refer other fixture. pylint: disable=redefined-outer-name
 def element_tree_station(xml_station: str) -> Element:
-    # Reason: The defusedxml's responsible.
-    return ElementTree.fromstring(xml_station, forbid_dtd=True)  # type: ignore[no-any-return]
+    return ElementTree.fromstring(xml_station, forbid_dtd=True)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -285,13 +285,13 @@ def model_program_area_id_none(element_tree_program: Element) -> Program:
 
 @pytest.fixture
 def database_session() -> Generator[SQLAlchemySession, None, None]:
-    """This fixture prepares database and fixture records."""
+    """Prepare database and fixture records."""
     yield from DatabaseForTest.database_session()
 
 
 @pytest.fixture
 def database_session_with_schema() -> Generator[SQLAlchemySession, None, None]:
-    """This fixture prepares database session and fixture records to reset database after each test."""
+    """Prepare database session and fixture records; reset database after each test."""
     yield from DatabaseForTest.database_session_with_schema()
 
 
@@ -301,7 +301,7 @@ def record_program(
     database_session_with_schema: SQLAlchemySession,
     element_tree_program: Element,
 ) -> SQLAlchemySession:
-    """This fixture prepares database session and fixture records to reset database after each test."""
+    """Prepare database session and fixture records; reset database after each test."""
     Program.save_all(XmlConverterProgram(date(2021, 1, 16), element_tree_program, "JP13").to_model())
     database_session_with_schema.flush()
     return database_session_with_schema

--- a/tests/radikoapi/test_radiko_api.py
+++ b/tests/radikoapi/test_radiko_api.py
@@ -30,5 +30,4 @@ class TestRadikoApi:
 
     @staticmethod
     def to_string(element_tree: "Element") -> str:
-        # Reason: The defusedxml's responsible.
-        return ElementTree.tostring(element_tree, encoding="unicode")  # type: ignore[no-any-return]
+        return ElementTree.tostring(element_tree, encoding="unicode")

--- a/tests/testlibraries/database_for_test.py
+++ b/tests/testlibraries/database_for_test.py
@@ -17,13 +17,13 @@ class DatabaseForTest:
 
     @classmethod
     def database_session(cls) -> "Generator[SQLAlchemySession, None, None]":
-        """This fixture prepares database session to reset database after each test."""
+        """Prepare database session and reset database after each test."""
         with DatabaseEngineManager(Session):
             yield Session()
 
     @classmethod
     def database_session_with_schema(cls) -> "Generator[SQLAlchemySession, None, None]":
-        """This fixture prepares database session and fixture records to reset database after each test."""
+        """Prepare database session and fixture records; reset database after each test."""
         with DatabaseEngineManager(Session) as engine:
             session = Session()
             Base.metadata.create_all(engine, checkfirst=False)


### PR DESCRIPTION
- **Migrate reusable workflows to pinned commit SHAs**: All GitHub Actions reusable workflow references under `.github/workflows/` have been updated from floating `@main` refs (`invoke-lint`) to dedicate repositories pinned at specific commit SHAs (e.g., `yukihiko-shinoda/reusable-workflow-invoke-lint-test@3deca67...`), following supply-chain security best practices.
- **Consolidate dev dependencies via `invokelint[basic]`**: Replaced the long list of individually pinned dev tools (`bandit`, `ruff`, `mypy`, `pylint`, `flake8`, `dlint`, `docformatter`, etc.) with a single `invokelint[basic]>=0.19.0` extras dependency, which now manages these as transitive deps. Added `types-defusedxml` and updated `semgrep` version constraints for Python 3.14 compatibility.
- **Fix mypy warnings — remove stale `# type: ignore` comments**: Added `types-defusedxml` stubs, allowing the `# type: ignore[no-any-return]` suppressions on `defusedxml.ElementTree` calls in `radiko_api.py`, `xml_parser.py`, `conftest.py`, and `tests/radikoapi/test_radiko_api.py` to be removed cleanly.
- **Fix D401 docstring style violations**: Updated all non-compliant docstrings across `radikopodcast/` and `tests/` to use imperative mood (e.g. `"Returns …"` → `"Return …"`, `"This method …"` → direct verb), conforming to the newly enabled Ruff `D401` rule.
- **Add Claude Code bind mount to compose.yml**: Added `~/.claude:/root/.claude:cached` volume to the Docker Compose service so Claude Code configuration is available inside the development container.
- **Normalize `pyproject.toml` indentation**: Converted all TOML array/table values from 4-space to 2-space indentation for consistency, and added explicit `D401` to `[tool.ruff.lint].select` alongside the existing `"ALL"`.
